### PR TITLE
Fix for issue #4 (TypeError: file.pipe is not a function)

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,6 @@ module.exports = function(spaces) {
 			}
 		});
 
-		file.pipe(replacer);
+		file.contents.pipe(replacer);
 	});
 };


### PR DESCRIPTION
When Gulp 4 updated from `gulp-4.0-alpha.2` to `gulp-4.0-alpha.3` they introduced a fairly large number of breaking changes.

One of those changes was no longer supporting `file.pipe()`.

[From one of the Gulp core contributors:](https://github.com/gulpjs/gulp/issues/2091)

> We removed the pipe method that existed on a Vinyl object because the API was very bad and did not do what people expected. Plugins now need to be handling null/streaming/buffer contents specifically instead of that opaque file.pipe API

To fix issue #4, `file.pipe(replacer);` just needs to be replaced with `file.contents.pipe(replacer);`